### PR TITLE
Return the chained promise

### DIFF
--- a/src/syncPosts.ts
+++ b/src/syncPosts.ts
@@ -147,7 +147,7 @@ export const ingestSlabPosts = async (uploadId: string) => {
 
     promise = promise.then(() => {
       console.info(`Syncing Slab posts batch ${oneIndex} of ${total} to Glean`);
-      processBatch(uploadId, docs, last ? PAGE.last : undefined)
+      return processBatch(uploadId, docs, last ? PAGE.last : undefined)
     });
   });
 


### PR DESCRIPTION
Promise chain was failing to wait because subsequent calls were not returning the next Promise.